### PR TITLE
Check 'X-Forwarded-For' header

### DIFF
--- a/README.pod
+++ b/README.pod
@@ -13,13 +13,13 @@ Mojolicious::Plugin::RemoteAddr - an easy way of getting remote ip address
 =head1 DESCRIPTION
 
 L<Mojolicious::Plugin::RemoteAddr> adds simple helper "remote_addr" which returns an ip address of a remote host, It tries getting remote ip in different ways.
-Firstly, it takes 'X-Real-IP' header. If it is empty it takes the ip from current request transaction.
+Firstly, it takes 'X-Real-IP' header. Secondly, it takes 'X-Forwarded-For' header. If they are empty it takes the ip from current request transaction.
 
 =head1 CONFIG
 
 =head2 order
 
-Lookup order. Default is ['x-real-ip', 'tx']
+Lookup order. Default is ['x-real-ip', 'x-forwarded-for', 'tx']
 
 Supported places:
 
@@ -28,6 +28,10 @@ Supported places:
 =item 'x-real-ip'  
 
 'X-Real-IP' request header
+
+=item 'x-forwarded-for'
+
+'X-Forwarded-For' request header
 
 =item 'tx' 
 

--- a/t/forwarded.t
+++ b/t/forwarded.t
@@ -1,0 +1,25 @@
+use Mojo::Base -strict;
+
+use Test::More;
+use Mojolicious::Lite;
+use Test::Mojo;
+
+plugin 'RemoteAddr';
+
+get '/ip' => sub {
+  my $self = shift;
+  $self->render( text => $self->remote_addr );
+};
+
+# IP from transaction
+my $t = Test::Mojo->new;
+
+# IP from X-Forwarded-For header
+$t->ua->on( start => sub {
+    my ( $ua, $tx ) = @_;
+    $tx->req->headers->header( 'X-Forwarded-For', '2.2.2.2' );
+});
+
+$t->get_ok('/ip')->status_is(200)->content_is('2.2.2.2', 'IP from X-Forwarded-For header');
+
+done_testing();


### PR DESCRIPTION
Latest versions of Apache HTTPD Server in reverse proxy mode are adding `X-Forwarded-For` header to proxied requests. Added checking this header into plugin.
